### PR TITLE
Comparing dispatch_get_current_queue() with dispatch_get_main_queue()…

### DIFF
--- a/Cocoa Spotify/common/Tests/SPConcurrencyTests.m
+++ b/Cocoa Spotify/common/Tests/SPConcurrencyTests.m
@@ -55,13 +55,13 @@ static NSString * const kImageLoadingTestURI = @"spotify:image:a0457147cb2972cf0
 	SPSession *session = [SPSession sharedSession];
 	
 	[session fetchOfflineKeyTimeRemaining:^(NSTimeInterval remainingTime) {
-		SPTestAssert(dispatch_get_current_queue() == dispatch_get_main_queue(), @"OfflineKeyTimeRemaining callback on wrong queue.");
+		SPTestAssert([NSThread isMainThread], @"OfflineKeyTimeRemaining callback on wrong queue.");
 	
 		[session fetchStoredCredentialsUserName:^(NSString *storedUserName) {
-			SPTestAssert(dispatch_get_current_queue() == dispatch_get_main_queue(), @"StoredCredentialsUserName callback on wrong queue.");
+			SPTestAssert([NSThread isMainThread], @"StoredCredentialsUserName callback on wrong queue.");
 			
 			[session fetchLoginUserName:^(NSString *loginUserName) {
-				SPTestAssert(dispatch_get_current_queue() == dispatch_get_main_queue(), @"FetchLoginUserName callback on wrong queue.");
+				SPTestAssert([NSThread isMainThread], @"FetchLoginUserName callback on wrong queue.");
 				SPPassTest();
 			}];
 		}];
@@ -74,35 +74,35 @@ static NSString * const kImageLoadingTestURI = @"spotify:image:a0457147cb2972cf0
 	SPSession *session = [SPSession sharedSession];
 	
 	[session albumForURL:nil callback:^(SPAlbum *album) {
-		SPTestAssert(dispatch_get_current_queue() == dispatch_get_main_queue(), @"albumForURL callback on wrong queue.");
+		SPTestAssert([NSThread isMainThread], @"albumForURL callback on wrong queue.");
 		SPTestAssert(album == nil, @"Album callback with nil URL gave %@", album);
 		
 		[session artistForURL:nil callback:^(SPArtist *artist) {
-			SPTestAssert(dispatch_get_current_queue() == dispatch_get_main_queue(), @"artistForURL callback on wrong queue.");
+			SPTestAssert([NSThread isMainThread], @"artistForURL callback on wrong queue.");
 			SPTestAssert(artist == nil, @"Artist callback with nil URL gave %@", artist);
 			
 			[session imageForURL:nil callback:^(SPImage *image) {
-				SPTestAssert(dispatch_get_current_queue() == dispatch_get_main_queue(), @"imageForURL callback on wrong queue.");
+				SPTestAssert([NSThread isMainThread], @"imageForURL callback on wrong queue.");
 				SPTestAssert(image == nil, @"Image callback with nil URL gave %@", image);
 				
 				[session playlistForURL:nil callback:^(SPPlaylist *playlist) {
-					SPTestAssert(dispatch_get_current_queue() == dispatch_get_main_queue(), @"playlistForURL callback on wrong queue.");
+					SPTestAssert([NSThread isMainThread], @"playlistForURL callback on wrong queue.");
 					SPTestAssert(playlist == nil, @"Playlist callback with nil URL gave %@", playlist);
 
 					[session searchForURL:nil callback:^(SPSearch *search) {
-						SPTestAssert(dispatch_get_current_queue() == dispatch_get_main_queue(), @"searchForURL callback on wrong queue.");
+						SPTestAssert([NSThread isMainThread], @"searchForURL callback on wrong queue.");
 						SPTestAssert(search == nil, @"Search callback with nil URL gave %@", search);
 
 						[session trackForURL:nil callback:^(SPTrack *track) {
-							SPTestAssert(dispatch_get_current_queue() == dispatch_get_main_queue(), @"trackForURL callback on wrong queue.");
+							SPTestAssert([NSThread isMainThread], @"trackForURL callback on wrong queue.");
 							SPTestAssert(track == nil, @"Track callback with nil URL gave %@", track);
 
 							[session userForURL:nil callback:^(SPUser *user) {
-								SPTestAssert(dispatch_get_current_queue() == dispatch_get_main_queue(), @"userForURL callback on wrong queue.");
+								SPTestAssert([NSThread isMainThread], @"userForURL callback on wrong queue.");
 								SPTestAssert(user == nil, @"User callback with nil URL gave %@", user);
 								
 								[session objectRepresentationForSpotifyURL:nil callback:^(sp_linktype linkType, id objectRepresentation) {
-									SPTestAssert(dispatch_get_current_queue() == dispatch_get_main_queue(), @"objectRepresentationForSpotifyURL callback on wrong queue.");
+									SPTestAssert([NSThread isMainThread], @"objectRepresentationForSpotifyURL callback on wrong queue.");
 									SPTestAssert(objectRepresentation == nil, @"Object representation callback with nil URL gave %@", objectRepresentation);
 									SPTestAssert(linkType == SP_LINKTYPE_INVALID, @"Object representation callback with nil URL gave linktype of %lu", linkType);
 									SPPassTest();
@@ -122,35 +122,35 @@ static NSString * const kImageLoadingTestURI = @"spotify:image:a0457147cb2972cf0
 	SPSession *session = [SPSession sharedSession];
 	
 	[session albumForURL:[NSURL URLWithString:kAlbumLoadingTestURI] callback:^(SPAlbum *album) {
-		SPTestAssert(dispatch_get_current_queue() == dispatch_get_main_queue(), @"albumForURL callback on wrong queue.");
+		SPTestAssert([NSThread isMainThread], @"albumForURL callback on wrong queue.");
 		SPTestAssert(album != nil, @"Album callback with valid URL gave nil");
 		
 		[session artistForURL:[NSURL URLWithString:kArtistLoadingTestURI] callback:^(SPArtist *artist) {
-			SPTestAssert(dispatch_get_current_queue() == dispatch_get_main_queue(), @"artistForURL callback on wrong queue.");
+			SPTestAssert([NSThread isMainThread], @"artistForURL callback on wrong queue.");
 			SPTestAssert(artist != nil, @"Artist callback with valid URL gave nil");
 			
 			[session imageForURL:[NSURL URLWithString:kImageLoadingTestURI] callback:^(SPImage *image) {
-				SPTestAssert(dispatch_get_current_queue() == dispatch_get_main_queue(), @"imageForURL callback on wrong queue.");
+				SPTestAssert([NSThread isMainThread], @"imageForURL callback on wrong queue.");
 				SPTestAssert(image != nil, @"Image callback with valid URL gave nil");
 				
 				[session playlistForURL:[NSURL URLWithString:kPlaylistLoadingTestURI] callback:^(SPPlaylist *playlist) {
-					SPTestAssert(dispatch_get_current_queue() == dispatch_get_main_queue(), @"playlistForURL callback on wrong queue.");
+					SPTestAssert([NSThread isMainThread], @"playlistForURL callback on wrong queue.");
 					SPTestAssert(playlist != nil, @"Playlist callback with valid URL gave nil");
 					
 					[session searchForURL:[NSURL URLWithString:kSearchLoadingTestURI] callback:^(SPSearch *search) {
-						SPTestAssert(dispatch_get_current_queue() == dispatch_get_main_queue(), @"searchForURL callback on wrong queue.");
+						SPTestAssert([NSThread isMainThread], @"searchForURL callback on wrong queue.");
 						SPTestAssert(search != nil, @"Search callback with valid URL gave nil");
 						
 						[session trackForURL:[NSURL URLWithString:kTrackLoadingTestURI] callback:^(SPTrack *track) {
-							SPTestAssert(dispatch_get_current_queue() == dispatch_get_main_queue(), @"trackForURL callback on wrong queue.");
+							SPTestAssert([NSThread isMainThread], @"trackForURL callback on wrong queue.");
 							SPTestAssert(track != nil, @"Track callback with valid URL gave nil");
 							
 							[session userForURL:[NSURL URLWithString:kUserLoadingTestURI] callback:^(SPUser *user) {
-								SPTestAssert(dispatch_get_current_queue() == dispatch_get_main_queue(), @"userForURL callback on wrong queue.");
+								SPTestAssert([NSThread isMainThread], @"userForURL callback on wrong queue.");
 								SPTestAssert(user != nil, @"User callback with valid URL gave nil");
 								
 								[session objectRepresentationForSpotifyURL:[NSURL URLWithString:kTrackLoadingTestURI] callback:^(sp_linktype linkType, id objectRepresentation) {
-									SPTestAssert(dispatch_get_current_queue() == dispatch_get_main_queue(), @"objectRepresentationForSpotifyURL callback on wrong queue.");
+									SPTestAssert([NSThread isMainThread], @"objectRepresentationForSpotifyURL callback on wrong queue.");
 									SPTestAssert(objectRepresentation != nil, @"Object representation callback with valid URL gave nil");
 									SPTestAssert(linkType != SP_LINKTYPE_INVALID, @"Object representation callback with valid URL gave linktype of %lu", linkType);
 									SPPassTest();
@@ -170,27 +170,27 @@ static NSString * const kImageLoadingTestURI = @"spotify:image:a0457147cb2972cf0
 	SPSession *session = [SPSession sharedSession];
 	
 	[SPAlbum albumWithAlbumURL:nil inSession:session callback:^(SPAlbum *album) {
-		SPTestAssert(dispatch_get_current_queue() == dispatch_get_main_queue(), @"albumWithAlbumURL callback on wrong queue.");
+		SPTestAssert([NSThread isMainThread], @"albumWithAlbumURL callback on wrong queue.");
 		SPTestAssert(album == nil, @"Album callback with nil URL gave %@", album);
 		
 		[SPArtist artistWithArtistURL:nil inSession:session callback:^(SPArtist *artist) {
-			SPTestAssert(dispatch_get_current_queue() == dispatch_get_main_queue(), @"artistWithArtistURL callback on wrong queue.");
+			SPTestAssert([NSThread isMainThread], @"artistWithArtistURL callback on wrong queue.");
 			SPTestAssert(artist == nil, @"Artist callback with nil URL gave %@", artist);
 			
 			[SPImage imageWithImageURL:nil inSession:session callback:^(SPImage *image) {
-				SPTestAssert(dispatch_get_current_queue() == dispatch_get_main_queue(), @"imageWithImageURL callback on wrong queue.");
+				SPTestAssert([NSThread isMainThread], @"imageWithImageURL callback on wrong queue.");
 				SPTestAssert(image == nil, @"Image callback with nil URL gave %@", image);
 				
 				[SPPlaylist playlistWithPlaylistURL:nil inSession:session callback:^(SPPlaylist *playlist) {
-					SPTestAssert(dispatch_get_current_queue() == dispatch_get_main_queue(), @"playlistWithPlaylistURL callback on wrong queue.");
+					SPTestAssert([NSThread isMainThread], @"playlistWithPlaylistURL callback on wrong queue.");
 					SPTestAssert(playlist == nil, @"Playlist callback with nil URL gave %@", playlist);
 					
 					[SPTrack trackForTrackURL:nil inSession:session callback:^(SPTrack *track) {
-						SPTestAssert(dispatch_get_current_queue() == dispatch_get_main_queue(), @"trackForTrackURL callback on wrong queue.");
+						SPTestAssert([NSThread isMainThread], @"trackForTrackURL callback on wrong queue.");
 						SPTestAssert(track == nil, @"Track callback with nil URL gave %@", track);
 						
 						[SPUser userWithURL:nil inSession:session callback:^(SPUser *user) {
-							SPTestAssert(dispatch_get_current_queue() == dispatch_get_main_queue(), @"userWithURL callback on wrong queue.");
+							SPTestAssert([NSThread isMainThread], @"userWithURL callback on wrong queue.");
 							SPTestAssert(user == nil, @"User callback with nil URL gave %@", user);
 							SPPassTest();
 						}];
@@ -207,27 +207,27 @@ static NSString * const kImageLoadingTestURI = @"spotify:image:a0457147cb2972cf0
 	SPSession *session = [SPSession sharedSession];
 	
 	[SPAlbum albumWithAlbumURL:[NSURL URLWithString:kAlbumLoadingTestURI] inSession:session callback:^(SPAlbum *album) {
-		SPTestAssert(dispatch_get_current_queue() == dispatch_get_main_queue(), @"albumForURL callback on wrong queue.");
+		SPTestAssert([NSThread isMainThread], @"albumForURL callback on wrong queue.");
 		SPTestAssert(album != nil, @"Album callback with valid URL gave nil");
 		
 		[SPArtist artistWithArtistURL:[NSURL URLWithString:kArtistLoadingTestURI] inSession:session callback:^(SPArtist *artist) {
-			SPTestAssert(dispatch_get_current_queue() == dispatch_get_main_queue(), @"artistForURL callback on wrong queue.");
+			SPTestAssert([NSThread isMainThread], @"artistForURL callback on wrong queue.");
 			SPTestAssert(artist != nil, @"Artist callback with valid URL gave nil");
 			
 			[SPImage imageWithImageURL:[NSURL URLWithString:kImageLoadingTestURI] inSession:session callback:^(SPImage *image) {
-				SPTestAssert(dispatch_get_current_queue() == dispatch_get_main_queue(), @"imageForURL callback on wrong queue.");
+				SPTestAssert([NSThread isMainThread], @"imageForURL callback on wrong queue.");
 				SPTestAssert(image != nil, @"Image callback with valid URL gave nil");
 				
 				[SPPlaylist playlistWithPlaylistURL:[NSURL URLWithString:kPlaylistLoadingTestURI] inSession:session callback:^(SPPlaylist *playlist) {
-					SPTestAssert(dispatch_get_current_queue() == dispatch_get_main_queue(), @"playlistForURL callback on wrong queue.");
+					SPTestAssert([NSThread isMainThread], @"playlistForURL callback on wrong queue.");
 					SPTestAssert(playlist != nil, @"Playlist callback with valid URL gave nil");
 					
 					[SPTrack trackForTrackURL:[NSURL URLWithString:kTrackLoadingTestURI] inSession:session callback:^(SPTrack *track) {
-						SPTestAssert(dispatch_get_current_queue() == dispatch_get_main_queue(), @"trackForURL callback on wrong queue.");
+						SPTestAssert([NSThread isMainThread], @"trackForURL callback on wrong queue.");
 						SPTestAssert(track != nil, @"Track callback with valid URL gave nil");
 						
 						[SPUser userWithURL:[NSURL URLWithString:kUserLoadingTestURI] inSession:session callback:^(SPUser *user) {
-							SPTestAssert(dispatch_get_current_queue() == dispatch_get_main_queue(), @"userForURL callback on wrong queue.");
+							SPTestAssert([NSThread isMainThread], @"userForURL callback on wrong queue.");
 							SPTestAssert(user != nil, @"User callback with valid URL gave nil");
 							SPPassTest();						
 						}];

--- a/Cocoa Spotify/common/Tests/SPMetadataTests.m
+++ b/Cocoa Spotify/common/Tests/SPMetadataTests.m
@@ -89,7 +89,7 @@ static NSString * const kTrackLoadingTestURI = @"spotify:track:5iIeIeH3LBSMK92cM
 								 type:SP_ARTISTBROWSE_NO_TRACKS
 							 callback:^(SPArtistBrowse *artistBrowse) {
 								 
-								 SPTestAssert(dispatch_get_current_queue() == dispatch_get_main_queue(), @"browseArtistAtURL callback on wrong queue.");
+								 SPTestAssert([NSThread isMainThread], @"browseArtistAtURL callback on wrong queue.");
 								 
 								 [SPAsyncLoading waitUntilLoaded:artistBrowse timeout:kSPAsyncLoadingDefaultTimeout then:^(NSArray *loadedItems, NSArray *notLoadedItems) {
 									 SPTestAssert(notLoadedItems.count == 0, @"ArtistBrowse loading timed out for %@", artistBrowse);
@@ -107,7 +107,7 @@ static NSString * const kTrackLoadingTestURI = @"spotify:track:5iIeIeH3LBSMK92cM
 						  inSession:[SPSession sharedSession]
 						   callback:^(SPAlbumBrowse *albumBrowse) {
 							   
-							   SPTestAssert(dispatch_get_current_queue() == dispatch_get_main_queue(), @"browseAlbumAtURL callback on wrong queue.");
+							   SPTestAssert([NSThread isMainThread], @"browseAlbumAtURL callback on wrong queue.");
 							   
 							   [SPAsyncLoading waitUntilLoaded:albumBrowse timeout:kSPAsyncLoadingDefaultTimeout then:^(NSArray *loadedItems, NSArray *notLoadedItems) {
 								   SPTestAssert(notLoadedItems.count == 0, @"AlbumBrowse loading timed out for %@", albumBrowse);

--- a/Cocoa Spotify/common/Tests/SPPlaylistTests.m
+++ b/Cocoa Spotify/common/Tests/SPPlaylistTests.m
@@ -123,7 +123,7 @@ static NSString * const kTrack2TestURI = @"spotify:track:2zpRYcfuvripcfzgWEj1c7"
 			
 			[container createPlaylistWithName:kTestPlaylistName callback:^(SPPlaylist *createdPlaylist) {
 				SPTestAssert(createdPlaylist != nil, @"Created nil playlist");
-				SPTestAssert(dispatch_get_current_queue() == dispatch_get_main_queue(), @"createPlaylistWithName callback on wrong queue.");
+				SPTestAssert([NSThread isMainThread], @"createPlaylistWithName callback on wrong queue.");
 				
 				self.playlist = createdPlaylist;
 				
@@ -158,7 +158,7 @@ static NSString * const kTrack2TestURI = @"spotify:track:2zpRYcfuvripcfzgWEj1c7"
 				[sself.playlist addItems:[NSArray arrayWithObjects:track1, track2, nil] atIndex:0 callback:^(NSError *error) {
 					
 					SPTestAssert(error == nil, @"Got error when adding to playlist: %@", error);
-					SPTestAssert(dispatch_get_current_queue() == dispatch_get_main_queue(), @"addItems callback on wrong queue.");
+					SPTestAssert([NSThread isMainThread], @"addItems callback on wrong queue.");
 					
 					// Tracks get converted to items.
 					NSArray *originalPlaylistTracks = [self.playlist.items valueForKey:@"item"];
@@ -168,7 +168,7 @@ static NSString * const kTrack2TestURI = @"spotify:track:2zpRYcfuvripcfzgWEj1c7"
 					
 					[sself.playlist moveItemsAtIndexes:[NSIndexSet indexSetWithIndex:0] toIndex:2 callback:^(NSError *moveError) {
 						SPTestAssert(moveError == nil, @"Move operation returned error: %@", moveError);
-						SPTestAssert(dispatch_get_current_queue() == dispatch_get_main_queue(), @"moveItemsAtIndexes callback on wrong queue.");
+						SPTestAssert([NSThread isMainThread], @"moveItemsAtIndexes callback on wrong queue.");
 						
 						NSArray *movedPlaylistTracks = [self.playlist.items valueForKey:@"item"];
 						SPTestAssert(movedPlaylistTracks.count == 2, @"Playlist doesn't have 2 tracks after move, instead has: %u", movedPlaylistTracks.count);
@@ -178,7 +178,7 @@ static NSString * const kTrack2TestURI = @"spotify:track:2zpRYcfuvripcfzgWEj1c7"
 						[sself.playlist removeItemAtIndex:0 callback:^(NSError *deletionError) {
 							
 							SPTestAssert(deletionError == nil, @"Removal operation returned error: %@", deletionError);
-							SPTestAssert(dispatch_get_current_queue() == dispatch_get_main_queue(), @"removeItemAtIndex		callback on wrong queue.");
+							SPTestAssert([NSThread isMainThread], @"removeItemAtIndex		callback on wrong queue.");
 							
 							NSArray *afterDeletionPlaylistTracks = [self.playlist.items valueForKey:@"item"];
 							SPTestAssert(afterDeletionPlaylistTracks.count == 1, @"Playlist doesn't have 1 tracks after track remove, instead has: %u", afterDeletionPlaylistTracks.count);
@@ -211,7 +211,7 @@ static NSString * const kTrack2TestURI = @"spotify:track:2zpRYcfuvripcfzgWEj1c7"
 			[container removeItem:self.playlist callback:^(NSError *error) {
 				
 				SPTestAssert(error == nil, @"Removal operation returned error: %@", error);
-				SPTestAssert(dispatch_get_current_queue() == dispatch_get_main_queue(), @"removeItem callback on wrong queue.");
+				SPTestAssert([NSThread isMainThread], @"removeItem callback on wrong queue.");
 				SPTestAssert(![container.flattenedPlaylists containsObject:self.playlist], @"Playlist container still contains playlist: %@", self.playlist);
 				self.playlist = nil;
 				SPPassTest();

--- a/Cocoa Spotify/common/Tests/SPPostTracksToInboxTests.m
+++ b/Cocoa Spotify/common/Tests/SPPostTracksToInboxTests.m
@@ -53,7 +53,7 @@ static NSString * const kTrackToSendURI = @"spotify:track:3O0kOIdSdb3xQnjoi1AjRD
 									   inSession:[SPSession sharedSession]
 										callback:^(NSError *error) {
 											SPTestAssert(error == nil, @"Post to inbox operation encountered error: %@", error);
-											SPTestAssert(dispatch_get_current_queue() == dispatch_get_main_queue(), @"Post tracks callback on wrong queue.");
+											SPTestAssert([NSThread isMainThread], @"Post tracks callback on wrong queue.");
 											SPPassTest();
 										}];
 	}];

--- a/Cocoa Spotify/common/Tests/SPSessionTests.m
+++ b/Cocoa Spotify/common/Tests/SPSessionTests.m
@@ -140,7 +140,7 @@ static NSString * const kTestPasswordUserDefaultsKey = @"TestPassword";
 	
 	[SPAsyncLoading waitUntilLoaded:[SPSession sharedSession] timeout:kSPAsyncLoadingDefaultTimeout then:^(NSArray *loadedItems, NSArray *notLoadedItems) {
 		
-		SPTestAssert(dispatch_get_current_queue() == dispatch_get_main_queue(), @"SPAsyncLoading callback on wrong queue.");
+		SPTestAssert([NSThread isMainThread], @"SPAsyncLoading callback on wrong queue.");
 		SPTestAssert(notLoadedItems.count == 0, @"Session loading timed out for %@", [SPSession sharedSession]);
 		
 		[SPAsyncLoading waitUntilLoaded:[SPSession sharedSession].user timeout:kSPAsyncLoadingDefaultTimeout then:^(NSArray *loadedUsers, NSArray *notLoadedUsers) {


### PR DESCRIPTION
… is not only deprecated since iOS6, but unreliable according to queue.h:

When dispatch_get_current_queue() is called on the main thread, it may or may not return the same value as dispatch_get_main_queue(). Comparing the two is not a valid way to test whether code is executing on the main thread.
